### PR TITLE
Fix Row Filtering Part 2

### DIFF
--- a/src/gam/display.py
+++ b/src/gam/display.py
@@ -154,28 +154,33 @@ def write_csv_file(csvRows, titles, list_type, todrive):
                 return True
         return False
 
+    def filterMatch(filterVal, columns, row):
+        for column in columns:
+            if filterVal[1] == 'regex':
+                if filterVal[2].search(str(row.get(column, ''))):
+                    return True
+            elif filterVal[1] == 'notregex':
+                if not filterVal[2].search(str(row.get(column, ''))):
+                    return True
+            elif filterVal[1] in ['date', 'time']:
+                if rowDateTimeFilterMatch(
+                    filterVal[1] == 'date', row.get(column, ''),
+                    filterVal[2], filterVal[3]):
+                    return True
+            elif filterVal[1] == 'count':
+                if rowCountFilterMatch(
+                    row.get(column, 0), filterVal[2], filterVal[3]):
+                    return True
+            else:  #boolean
+                if rowBooleanFilterMatch(
+                    row.get(column, False), filterVal[2]):
+                    return True
+        return False
+
     def rowFilterMatch(filters, columns, row):
         for c, filterVal in iter(filters.items()):
-            for column in columns[c]:
-                if filterVal[1] == 'regex':
-                    if not filterVal[2].search(str(row.get(column, ''))):
-                        return False
-                elif filterVal[1] == 'notregex':
-                    if filterVal[2].search(str(row.get(column, ''))):
-                        return False
-                elif filterVal[1] in ['date', 'time']:
-                    if not rowDateTimeFilterMatch(
-                        filterVal[1] == 'date', row.get(column, ''),
-                        filterVal[2], filterVal[3]):
-                        return False
-                elif filterVal[1] == 'count':
-                    if not rowCountFilterMatch(
-                        row.get(column, 0), filterVal[2], filterVal[3]):
-                        return False
-                else:  #boolean
-                    if not rowBooleanFilterMatch(
-                        row.get(column, False), filterVal[2]):
-                        return False
+            if not filterMatch(filterVal, columns[c], row):
+                return False
         return True
 
     if GC_Values[GC_CSV_ROW_FILTER] or GC_Values[GC_CSV_ROW_DROP_FILTER]:


### PR DESCRIPTION
Row Filtering
There can be multiple filters, a filter can match multiple columns (wildcard).
The semantics should be:
For row keep filters, if all filters match, the row is kept.
For row drop filters, if any filter matches, the row is dropped.

For an individual filter that specifies multiple columns, there is a match if any column matches.

Prior to PR 1433, the semantics for keep/drop were reversed; the semantics for multiple columns was correct.

PR 1433 corrected the semantics for keep/drop but broke the semantics for multiple columns.

This PR corrects the semantics for multiple columns.
