### PR TITLE
Add Frontline Worker alias

### DIFF
--- a/src/gam/var.py
+++ b/src/gam/var.py
@@ -206,7 +206,7 @@ SKUS = {
     },
     '1010020030': {
         'product': 'Google-Apps',
-        'aliases': ['workspacefrontline', 'workspacefrontlineworker'],
+        'aliases': ['wsflw', 'workspacefrontline', 'workspacefrontlineworker'],
         'displayName': 'Workspace Frontline'
     },
     '1010340002': {


### PR DESCRIPTION
Was trying to find the abbreviation for Frontline Worker licenses and noticed they weren't documented here:
https://github.com/GAM-team/GAM/wiki/LicenseExamples

But were stored in variables in src/gam/var.py, added a short one to match the other Google Workspace licenses, but please could the wiki get updated too? Didn't realise you can't submit a PR to it.