### PR TITLE
Fix Chrome schema enum processing

### DIFF
--- a/src/gam/gapi/chromepolicy.py
+++ b/src/gam/gapi/chromepolicy.py
@@ -167,7 +167,7 @@ def build_schemas(svc=None, sfilter=None):
                     for an_enum in schema['definition']['enumType']:
                         if an_enum['name'] == type_name:
                             setting_dict['enums'] = [enum['name'] for enum in an_enum['value']]
-                            setting_dict['enum_prefix'] = utils.commonprefix(setting_dict['enums'])
+                            setting_dict['enum_prefix'] = utils.commonprefix(setting_dict['enums'], True)
                             prefix_len = len(setting_dict['enum_prefix'])
                             setting_dict['enums'] = [enum[prefix_len:] for enum \
                                                      in setting_dict['enums'] \

--- a/src/gam/utils.py
+++ b/src/gam/utils.py
@@ -96,9 +96,13 @@ class _DeHTMLParser(HTMLParser):
                       re.sub(r'\n +', '\n', ''.join(self.__text))).strip()
 
 
-def commonprefix(m):
+def commonprefix(m, checkEnum=False):
     '''Given a list of strings m, return string which is prefix common to all'''
     s1 = min(m)
+    if checkEnum:
+        loc = s1.find('ENUM_')
+        if loc > 0:
+            return s1[:loc+5]
     s2 = max(m)
     for i, c in enumerate(s1):
         if c != s2[i]:


### PR DESCRIPTION
Prefix should not include anything after ENUM_
```
        name: RollbackToTargetVersionEnum
          value:
            name: ROLLBACK_TO_TARGET_VERSION_ENUM_ROLLBACK_DISABLED
              number: 1
            name: ROLLBACK_TO_TARGET_VERSION_ENUM_ROLLBACK_AND_RESTORE_IF_POSSIBLE
              number: 3
```