### PR TITLE
Added Alert Center commands for displaying and setting Settings #1814

### DIFF
--- a/src/GamCommands.txt
+++ b/src/GamCommands.txt
@@ -539,6 +539,7 @@ If an item contains spaces, it should be surrounded by ".
         Must match this Python Regular Expression: [a-zA-Z0-9 '"!-]{4,30}
 <PropertyKey> ::= <String>
 <PropertyValue> ::= <String>
+<PubSubTopicName> ::= <String>
 <QueryAlert> ::= <String>
         See: https://developers.google.com/admin-sdk/alertcenter/guides/query-filters
 <QueryBrowser> ::= <String>
@@ -1553,6 +1554,9 @@ gam show alertfeedback [alert <AlertID>] [filter <QueryAlert>] [orderby createti
         [formatjson]
 gam print alertfeedback [todrive <ToDriveAttribute>*] [alert <AlertID>] [filter <QueryAlert>] [orderby createtime [ascending|descending]]
         [formatjson [quotechar <Character>]]
+
+gam alerts showsettings
+gam alerts setsettings <PubSubTopicName>
 
 # Aliases
 

--- a/src/gam/gamlib/glclargs.py
+++ b/src/gam/gamlib/glclargs.py
@@ -1013,6 +1013,7 @@ class GamCLArgs():
   OB_PROJECT_ID_ENTITY = 'ProjectIDEntity'
   OB_PROPERTY_KEY = 'PropertyKey'
   OB_PROPERTY_VALUE = 'PropertyValue'
+  OB_PUBSUB_TOPIC_NAME = 'PubSubTopicName'
   OB_QUERY = 'Query'
   OB_QUERY_ITEM = 'QueryItem'
   OB_QUERY_LIST = 'QueryList'

--- a/wiki/Alert-Center.md
+++ b/wiki/Alert-Center.md
@@ -7,6 +7,7 @@
 - [Display alerts](#display-alerts)
 - [Manage alert feedback](#manage-alert-feedback)
 - [Display alert feedback](#display-alert-feedback)
+- [Configuring settings](#configuring-settings)
 
 ## API documentation
 * [Alert Center API](https://developers.google.com/admin-sdk/alertcenter/reference/rest/)
@@ -19,6 +20,7 @@
 ```
 <AlertID> ::= <String>
 <QueryAlert> ::= <String> See: https://developers.google.com/admin-sdk/alertcenter/guides/query-filters
+<PubSubTopicName> ::= <String>
 ```
 ## Introduction
 For an introduction, start here: https://support.google.com/a/answer/9105393
@@ -95,3 +97,13 @@ the quote character itself, the column delimiter (comma by default) and new-line
 When using the `formatjson` option, double quotes are used extensively in the data resulting in hard to read/process output.
 The `quotechar <Character>` option allows you to choose an alternate quote character, single quote for instance, that makes for readable/processable output.
 `quotechar` defaults to `gam.cfg/csv_output_quote_char`. When uploading CSV files to Google, double quote `"` should be used.
+S
+## Configuring settings
+
+Alert Center can be configured to send notifications to a Google Cloud Pub/Sub topic, but it first requires configuration. See https://developers.google.com/workspace/admin/alertcenter/guides/notifications for information.
+
+Gam can be used to display or modify the settings:
+```
+gam alerts showsettings
+gam alarts setsettings <PubSubTopicName>
+```


### PR DESCRIPTION
I am by no means familiar with the Gam code, or really Python either. I had a need to set these settings, so I thought it would be good to "send the changes back" for others to also be able to use. Hopefully this is close to what you would want in terms of a PR. This seems to work in my very limited testing. I did not try "unsetting" the topic, but that might require a different command syntax to support that. Suggestions welcome of couse.