### PR TITLE
Adds workflow to dispatch event for homebrew tap update when a new release is created

### DIFF
--- a/.github/workflows/notify-homebrew.yml
+++ b/.github/workflows/notify-homebrew.yml
@@ -1,0 +1,27 @@
+name: Notify Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-homebrew:
+    # Only run for non-prerelease, non-draft releases
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Homebrew Tap Update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: Zircoz/homebrew-gam
+          event-type: gam-release
+          client-payload: |-
+            {
+              "version": "${{ github.event.release.tag_name }}",
+              "release_name": "${{ github.event.release.name }}",
+              "release_url": "${{ github.event.release.html_url }}",
+              "tarball_url": "${{ github.event.release.tarball_url }}",
+              "triggered_by": "${{ github.actor }}"
+            }


### PR DESCRIPTION
Until now, the homebrew tap's update depends on polling the GAM repo for new release & comparing the latest w the one in tap.

This PR, changes that to send an event with release version that will trigger the action in homebbrew tap to update.
The polling method is still there as fallback but I'm hoping to remove it in the far future. (baby steps :))

Homerew tap: https://github.com/Zircoz/homebrew-GAM 

this is a by product of #1660 