### PR TITLE
Fix DASA: route Directory/Reports via OAuth2 access tokens (fixes #1902)

### DIFF
--- a/src/gam/__init__.py
+++ b/src/gam/__init__.py
@@ -4615,7 +4615,8 @@ def getOauth2TxtCredentials(exitOnError=True, api=None, noDASA=False, refreshOnl
     if jsonData:
       try:
         if api in API.APIS_NEEDING_ACCESS_TOKEN:
-          return (False, getSvcAcctCredentials(API.APIS_NEEDING_ACCESS_TOKEN[api], userEmail=None, forceOauth=True))
+          subject = GC.Values[GC.ADMIN_EMAIL] if api in API.APIS_NEEDING_DASA_SUBJECT else None
+          return (False, getSvcAcctCredentials(API.APIS_NEEDING_ACCESS_TOKEN[api], userEmail=subject, forceOauth=True))
         jsonDict = json.loads(jsonData)
         api, _, _ = API.getVersion(api)
         audience = f'https://{api}.googleapis.com/'

--- a/src/gam/gamlib/glapi.py
+++ b/src/gam/gamlib/glapi.py
@@ -152,7 +152,32 @@ EXTRA_SCOPES = {
 EXTRA_SCOPES[CLOUDRESOURCEMANAGERV1] = EXTRA_SCOPES[CLOUDRESOURCEMANAGER]
 
 APIS_NEEDING_ACCESS_TOKEN = {
-  CBCM: ['https://www.googleapis.com/auth/admin.directory.device.chromebrowsers']
+  CBCM: ['https://www.googleapis.com/auth/admin.directory.device.chromebrowsers'],
+  # admin.googleapis.com (Directory) rejects self-signed JWT bearer tokens
+  # with `401 "Expected OAuth 2 access token"`, so DASA must exchange the
+  # JWT for an OAuth 2.0 access token. Only readonly scopes are requested
+  # here; write operations under DASA are not addressed by this entry.
+  DIRECTORY: [
+    'https://www.googleapis.com/auth/admin.directory.customer.readonly',
+    'https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly',
+    'https://www.googleapis.com/auth/admin.directory.device.mobile.readonly',
+    'https://www.googleapis.com/auth/admin.directory.domain.readonly',
+    'https://www.googleapis.com/auth/admin.directory.group.readonly',
+    'https://www.googleapis.com/auth/admin.directory.orgunit.readonly',
+    'https://www.googleapis.com/auth/admin.directory.resource.calendar.readonly',
+    'https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly',
+    'https://www.googleapis.com/auth/admin.directory.user.readonly',
+    ],
+  REPORTS: [
+    'https://www.googleapis.com/auth/admin.reports.audit.readonly',
+    'https://www.googleapis.com/auth/admin.reports.usage.readonly',
+    ],
+  }
+# APIs in APIS_NEEDING_ACCESS_TOKEN that additionally require DWD
+# impersonation (sub=admin_email) in DASA mode. CBCM does not impersonate.
+APIS_NEEDING_DASA_SUBJECT = {
+  DIRECTORY,
+  REPORTS,
   }
 #
 DEPRECATED_SCOPES = {


### PR DESCRIPTION
Fixes #1902 — see that issue for the reproduce, the
proof-it-isn't-DwD, and the source-level diagnosis.

## What this PR does

1. Register `DIRECTORY` and `REPORTS` in `APIS_NEEDING_ACCESS_TOKEN`
   with the **readonly** scope subset, so the DASA path routes them
   through `getSvcAcctCredentials(..., forceOauth=True)` instead of
   self-signed JWT bearer. `admin.googleapis.com` rejects self-signed
   JWTs with `401 "Expected OAuth 2 access token"`.
2. Add `APIS_NEEDING_DASA_SUBJECT = {DIRECTORY, REPORTS}` and read it
   at the DASA credentials callsite so `userEmail=GC.Values[GC.ADMIN_EMAIL]`
   is passed when the API needs DWD impersonation. CBCM's existing
   no-subject behaviour is preserved (CBCM is not in the set, so the
   code path for it is byte-identical to before).

```diff
-          return (False, getSvcAcctCredentials(API.APIS_NEEDING_ACCESS_TOKEN[api], userEmail=None, forceOauth=True))
+          subject = GC.Values[GC.ADMIN_EMAIL] if api in API.APIS_NEEDING_DASA_SUBJECT else None
+          return (False, getSvcAcctCredentials(API.APIS_NEEDING_ACCESS_TOKEN[api], userEmail=subject, forceOauth=True))
```

## Scope list — why readonly only

Including write scopes (e.g. `admin.directory.user`) would break the
OAuth2 exchange for any user whose SA doesn't have DwD for every
scope — `unauthorized_client` fails the whole request, not a subset.
That's strictly worse than today's partial-JWT behaviour for read
paths. This patch fixes the read surface that's definitely broken
right now; write/DASA can follow.

`admin.directory.userschema.readonly` is also omitted because it's
not in the typical DwD authorize-all templates most users paste from
the wiki. Easy to add if you disagree.

## Test plan

Tested locally against `main` (commit `726f061`) with a fresh venv
and a real Workspace tenant + SA with DwD. `enable_dasa = true`.

| Command                              | Before | After  |
| ------------------------------------ | ------ | ------ |
| `gam info domain`                    | 403    | 200    |
| `gam info customer`                  | 403    | 200    |
| `gam info user admin@example.com`    | 403    | 200    |
| `gam print users maxResults 3`       | 403    | 200    |

CBCM regression check was not run (no CBCM-enabled tenant on hand).
The code path for CBCM is byte-identical to the previous behaviour
because `CBCM not in APIS_NEEDING_DASA_SUBJECT` → `subject = None`,
matching the old hard-coded `userEmail=None`.

## Open questions — happy to adjust

- Should the same fix extend to `DATATRANSFER`, `GROUPSSETTINGS`,
  `LICENSING`, `RESELLER`, and other admin-scoped APIs? I kept the
  surface minimal here to get the shape right before expanding.
- Would you prefer the DASA scope list to come from
  `oauth2service.json`'s `us_scopes` rather than a hardcoded dict in
  `glapi.py`? I considered it but kept this patch consistent with
  the existing CBCM entry style for minimum diff.

Not attached to any specific shape — tell me how you'd like it and
I'll adapt.
