### PR TITLE
Fix uv override key: `overrides` -> `override-dependencies`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ packages = [
 ]
 
 [tool.uv]
-overrides = [
+override-dependencies = [
     "urllib3>=2.7.0",
 ]
 

--- a/src/tools/apply_overrides.py
+++ b/src/tools/apply_overrides.py
@@ -73,13 +73,13 @@ def main():
         pyproject["tool"]["uv"] = {}
 
     # 3. Update overrides list
-    original_overrides = pyproject["tool"]["uv"].get("overrides", [])
-    
+    original_overrides = pyproject["tool"]["uv"].get("override-dependencies", [])
+
     if overrides:
-        pyproject["tool"]["uv"]["overrides"] = overrides
+        pyproject["tool"]["uv"]["override-dependencies"] = overrides
     else:
         # If all overrides are expired, drop the key entirely
-        pyproject["tool"]["uv"].pop("overrides", None)
+        pyproject["tool"]["uv"].pop("override-dependencies", None)
 
     # 4. Save changes only if they differ
     if original_overrides != overrides:


### PR DESCRIPTION
## Summary

The `[tool.uv]` block in `pyproject.toml` (and the `apply_overrides.py` script that writes it) uses the key `overrides`, but uv expects `override-dependencies`. With the wrong key, uv emits a warning during settings discovery and silently ignores the entire `[tool.uv]` block — so any entries in `dep-overrides.txt` have no effect on dependency resolution.

This is currently visible in the wild: the most recent dep upgrade (#1911, 2026-04-28) wrote `urllib3>=2.7.0` as an override, but the constraint never reached the resolver. urllib3 ended up at 2.7.0 in `uv.lock` only because #1910 raised the direct dependency, not because the override applied.

### Repro

Running any `uv` command in the project root with current `main`:

```
$ uv run python src/gam.py version
warning: Failed to parse `/.../pyproject.toml` during settings discovery:
  TOML parse error at line 69, column 1
     |
  69 | overrides = [
     | ^^^^^^^^^
  unknown field `overrides`, expected one of ..., `override-dependencies`, ...
```

After this PR the warning is gone and uv honors the override block.

### Changes

- `pyproject.toml`: rename existing `overrides` key to `override-dependencies`.
- `src/tools/apply_overrides.py`: write/read `override-dependencies` so future runs of the upgrade-deps workflow use the correct key.

Reference: https://docs.astral.sh/uv/reference/settings/#override-dependencies

## Test plan

- [x] `uv run python src/gam.py version` — no TOML parse warning, GAM runs.
- [x] Confirmed key name against uv 0.9.x docs and uv's own error message listing valid fields.